### PR TITLE
Add G5 instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ Form input parameters for configuring a bundle for deployment.
           - P2 General Purpose GPU Extra Large (4 vCPUs, 61.0 GiB)
           - P2 General Purpose GPU Eight Extra Large (32 vCPUs, 488.0 GiB)
           - P2 General Purpose GPU 16xlarge (64 vCPUs, 732.0 GiB)
+          - G5 Single GPU Extra Large (4 vCPUs, 16 GiB)
+          - G5 Single GPU Two Extra Large (8 vCPUs, 32 GiB)
+          - G5 Single GPU Four Extra Large (16 vCPUs, 64 GiB)
       - **`max_size`** *(integer)*: Maximum number of instances in the node group. Minimum: `0`. Default: `10`.
       - **`min_size`** *(integer)*: Minimum number of instances in the node group. Minimum: `0`. Default: `1`.
       - **`name`** *(string)*: The name of the node group. Default: ``.

--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -118,6 +118,12 @@ params:
                     const: p2.8xlarge
                   - title: P2 General Purpose GPU 16xlarge (64 vCPUs, 732.0 GiB)
                     const: p2.16xlarge
+                  - title: G5 Single GPU Extra Large (4 vCPUs, 16 GiB)
+                    const: g5.xlarge
+                  - title: G5 Single GPU Two Extra Large (8 vCPUs, 32 GiB)
+                    const: g5.2xlarge
+                  - title: G5 Single GPU Four Extra Large (16 vCPUs, 64 GiB)
+                    const: g5.4xlarge
         ingress:
           title: Ingress
           description: Configure network ingress for your ECS cluster


### PR DESCRIPTION
Fix for [add-g5-instances-to-aws-ecs-bundle](https://roadmap.massdriver.cloud/bundles/add-g5-instances-to-aws-ecs-bundle-cll30oy1z00b5ob29042vcj7v)

Added the following G5 instances:
- G5 Single GPU Extra Large (4 vCPUs, 16 GiB)
- G5 Single GPU Two Extra Large (8 vCPUs, 32 GiB)
- G5 Single GPU Four Extra Large (16 vCPUs, 64 GiB)

Ref:
[AWS G5 Instances](https://aws.amazon.com/ec2/instance-types/g5/)